### PR TITLE
Fix k indexing; add test for reverse k order; clarify k.

### DIFF
--- a/micro-apps/p3/micro_sed_driver.f90
+++ b/micro-apps/p3/micro_sed_driver.f90
@@ -24,6 +24,6 @@ program micro_sed
   call p3_init()
 
   dt = args(7)
-  call micro_sed_func_wrap(args(1), args(2), args(3), args(4), args(5), args(6), dt)
+  call micro_sed_func_wrap(args(1), args(2), 1, args(3), args(4), args(5), args(6), dt)
 
 end program micro_sed


### PR DESCRIPTION
There seems to have been an inconsistency before. kts:kte is used to declare
array indexing. I believe in that context, Fortran requires kts <= kte. But the
docs said kts was *always* the top index, which conflicts with the first
point. Indeed, a gfortran build, at least, seg faults when kts > kte.

Thus, I added an explicit kdir argument, and doc'ed it.

With both directions now working, I added a test so that now the same ICs are run twice, the second time with indexing the opposite of the first.