### PR TITLE
Add Albany's FPE method to run_and_cmp to address issue #22.

### DIFF
--- a/micro-apps/CMakeLists.txt
+++ b/micro-apps/CMakeLists.txt
@@ -8,6 +8,7 @@ include(CTest)
 set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Select build type.")
 set(DOUBLE_PRECISION TRUE CACHE LOGICAL "Set to double precision (default True)")
 set(ENABLE_TRACING FALSE CACHE LOGICAL "Enable detailed tracing")
+set(ENABLE_FPE FALSE CACHE LOGICAL "Enable floating point error exception")
 
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall -cpp")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -19,6 +20,10 @@ endif()
 
 if (${ENABLE_TRACING})
   add_definitions(-DTRACE)
+endif()
+
+if (${ENABLE_FPE})
+  add_definitions(-DFPE)
 endif()
 
 enable_testing()

--- a/micro-apps/p3/run_and_cmp.cpp
+++ b/micro-apps/p3/run_and_cmp.cpp
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <exception>
 
+#ifdef FPE
+# include <xmmintrin.h>
+#endif
+
 // Nothing in this file is intended to be indicative of the eventual perf
 // portable impl. E.g., Kokkos is not used here. The objective is simply to test
 // for input/output regression errors.
@@ -261,6 +265,14 @@ static void expect_another_arg (Int i, Int argc) {
 }
 
 int main (int argc, char** argv) {
+#ifdef FPE
+  _MM_SET_EXCEPTION_MASK(_MM_GET_EXCEPTION_MASK() &
+                         ~( _MM_MASK_INVALID |
+                            _MM_MASK_DIV_ZERO |
+                            _MM_MASK_OVERFLOW |
+                            _MM_MASK_UNDERFLOW ));
+#endif
+
   if (argc == 1) {
     std::cout <<
       argv[0] << " [options] baseline-filename\n"


### PR DESCRIPTION
Optionally check for various types of floating point exceptions.

This works for both C++ and Fortran code. Add -DENABLE_FPE=TRUE to your configuration.