### PR TITLE
Regression test multiple columns (fix #26).

### DIFF
--- a/micro-apps/p3/initial_conditions.cpp
+++ b/micro-apps/p3/initial_conditions.cpp
@@ -11,11 +11,11 @@ extern "C" {
 void fully_populate_input_data(Int ni, Int nk, Real** qr, Real** nr, Real** th, Real** dzq, Real** pres)
 {
   ic::MicroSedData<Real> data(ni, nk);
-  data.populate();
+  populate(data);
 
   for (auto item : { std::make_pair(data.qr, *qr), std::make_pair(data.nr, *nr), std::make_pair(data.th, *th),
                      std::make_pair(data.dzq, *dzq), std::make_pair(data.pres, *pres) }) {
-    std::copy(item.first, item.first + (ni, nk), item.second);
+    std::copy(item.first, item.first + ni*nk, item.second);
   }
 }
 

--- a/micro-apps/p3/micro_sed_vanilla.hpp
+++ b/micro-apps/p3/micro_sed_vanilla.hpp
@@ -85,7 +85,7 @@ void populate_input(const int its, const int ite, const int kts, const int kte,
 
   ic::MicroSedData<Real> default_data(num_horz, num_vert);
   if (data == nullptr) {
-    default_data.populate();
+    populate(default_data);
     data = &default_data;
   }
 


### PR DESCRIPTION
Add a multiple-column test to run_and_cmp. Both the single-column and
multiple-column cases are tested. In the second test, the baseline comparison is
on the final column only, but the impls are run with multiple columns. The same
baseline data are used for both tests.