### PR TITLE
Nano-app to study vectorization.

### DIFF
--- a/micro-apps/p3/CMakeLists.txt
+++ b/micro-apps/p3/CMakeLists.txt
@@ -29,8 +29,14 @@ target_link_libraries(micro_sed_vanilla microsed)
 add_executable(micro_sed_vanilla_kokkos micro_sed_vanilla_driver_kokkos.cpp)
 target_link_libraries(micro_sed_vanilla_kokkos microsed)
 
+add_executable(nanoapp vec.cpp)
+target_include_directories (nanoapp PUBLIC ${SCREAM_MICRO_APPS_INCLUDES})
+target_link_libraries (nanoapp ${SCREAM_MICRO_APPS_LIBRARIES})
+set_target_properties (nanoapp PROPERTIES LINK_FLAGS ${SCREAM_MICRO_APPS_LINK_FLAGS})
+
 add_test(run_unit_test unit_test_f90)
 add_test(run_micro_sed micro_sed 1 111 1 111 1 1 300 30) # kts kte ni nk its ite dt ts
 add_test(micro_sed_func_regression run_and_cmp run_and_cmp.baseline)
 add_test(run_micro_sed_vanilla micro_sed_vanilla 1 111 1 111 1 1 300 30)
 add_test(run_micro_sed_vanilla_kokkos micro_sed_vanilla_kokkos 1 111 1 111 1 1 300 30)
+add_test(nanoapp nanoapp -nc 4 -ns 100)

--- a/micro-apps/p3/vec.cpp
+++ b/micro-apps/p3/vec.cpp
@@ -286,7 +286,6 @@ void step (const Int& c, const Real& dt, Array<Real>& rho,
 
 void step (const Real& dt, const Int& nstep, Array<Real>& rho,
            Array<Real>& work) {
-  using C = problem::consts;
 # pragma omp parallel for
   for (Int c = 0; c < rho.extent_int(0); ++c)  
     for (Int i = 0; i < nstep; ++i)
@@ -971,6 +970,7 @@ namespace driver {
 Int unittest () {
   using c = problem::consts;
   static constexpr Int ncol = 4, N = c::ncell*ncol;
+  static constexpr Real tol = 1e-14;
   const Real dt = 0.5*c::dx/c::u_max;
   const Int nstep = Int(1.2*c::ncell);
   Real ic[N], work[ncol*(c::ncell+1)];
@@ -985,7 +985,7 @@ Int unittest () {
   {
     for (Int i = 0; i < N; ++i) r1[i] = ic[i];
     vec1::step(ncol, dt, nstep, r1, work);
-    if (util::reldif(r, r1, N) > 0) { std::cout << "vec1 failed\n"; ++nerr; }
+    if (util::reldif(r, r1, N) > tol) { std::cout << "vec1 failed\n"; ++nerr; }
   }
   {
     vec2::RealPack rho[ncol*vec2::consts::npack],
@@ -994,7 +994,7 @@ Int unittest () {
     for (Int i = 0; i < N; ++i) rp[i] = ic[i];
     vec2::step(ncol, dt, nstep, rho, work);
     const auto re = util::reldif(r, rp, N);
-    if (re > 0) {
+    if (re > tol) {
       std::cout << "vec2 re " << re << "\n";
       ++nerr;
     }
@@ -1006,7 +1006,7 @@ Int unittest () {
     for (Int i = 0; i < N; ++i) rp[i] = ic[i];
     packsimd::step(ncol, dt, nstep, rho, work);
     const auto re = util::reldif(r, rp, N);
-    if (re > 0) {
+    if (re > tol) {
       std::cout << "packsimd re " << re << "\n";
       ++nerr;
     }
@@ -1019,7 +1019,7 @@ Int unittest () {
         rho(c,i) = ic[c::ncell*c + i];
     koarr::step(dt, nstep, rho, work);
     const auto re = util::reldif(r, &rho(0,0), N);
-    if (re > 0) {
+    if (re > tol) {
       std::cout << "koarr re " << re << "\n";
       ++nerr;
     }
@@ -1036,7 +1036,7 @@ Int unittest () {
     ko::step(dt, nstep, rho, work);
     Kokkos::deep_copy(rhom, rho);
     const auto re = util::reldif(r, &rhom(0,0), N);
-    if (re > 0) {
+    if (re > tol) {
       std::cout << "ko re " << re << "\n";
       ++nerr;
     }
@@ -1052,7 +1052,7 @@ Int unittest () {
     kopack::step(dt, nstep, rho, work);
     Kokkos::deep_copy(rhom, rho);
     const auto re = util::reldif(r, &rhom(0,0)[0], N);
-    if (re > 0) {
+    if (re > tol) {
       std::cout << "kopack re " << re << "\n";
       ++nerr;
     }


### PR DESCRIPTION
This nano-app looks at a stripped-down sedimentation loop with explicit-Euler
first-order upwind.

unittest() checks that all impls are right.

measure_perf() looks at various impls.

namespace ko has a true Kokkos impl that runs on GPU. All other namespaces are
meant to study trade offs relative to this true Kokkos impl.

namespace vec2 has the start of explicit use of intrinsics. So far, on SKX, it
appears that auto-vectorization is nearly perfect, so use of intrinsics has yet
to yield speedup. In addition, it appears that 256-bit-wide vectors can be
better than 512-bit-wide on SKX. Have not checked performance on KNL yet.

Next step is to run with multiple columns.