### PR TITLE
Tweaks to threading stuff.

### DIFF
--- a/micro-apps/p3/micro_sed.f90
+++ b/micro-apps/p3/micro_sed.f90
@@ -272,7 +272,7 @@ contains
     real, dimension(ni,nk), target :: qr, nr, th, dzq, pres
     real, dimension(chunksize) :: cprt_liq
     real, dimension(ni), target :: prt_liq
-    real :: start, finish
+    real(8) :: start, finish
     integer :: ti, ci, nchunk, cni, cnk, ws, i
     logical :: ok
 
@@ -299,8 +299,12 @@ contains
     end do
 #else
     do ti = 1, ts
-       call micro_sed_func(1, nk, kdir, 1, ni, dt, &
-            qr, nr, th, dzq, pres, prt_liq)
+!$OMP PARALLEL DO DEFAULT(SHARED)
+       do i = 1, ni
+          call micro_sed_func(1, nk, kdir, 1, 1, dt, &
+               qr(i,:), nr(i,:), th(i,:), dzq(i,:), pres(i,:), prt_liq(i))
+       end do
+!$OMP END PARALLEL DO
     end do
 #endif
 


### PR DESCRIPTION
Use real(8) for start, finish so they work in single precision builds. On SKX
with ifort in SP build, I was seeing 0 elapsed time.

Add threading to the CHUNKSIZE 0 case for comparison.