### PR TITLE
Config and regression: If DEBUG, do things to make KNL testable.

### DIFF
--- a/micro-apps/CMakeLists.txt
+++ b/micro-apps/CMakeLists.txt
@@ -69,11 +69,22 @@ elseif ("${KOKKOS_GMAKE_ARCH}" STREQUAL "SKX")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -xCORE-AVX512")
 endif()
 
+STRING(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_ci)
+if (CMAKE_BUILD_TYPE_ci STREQUAL "debug")
+  message("Disabling vectorization in this DEBUG build.")
+  set(ENABLE_FPE TRUE)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-vec -fp-model strict")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -no-vec -fp-model strict")
+  endif ()
+endif ()
+
 if (${ENABLE_TRACING})
   add_definitions(-DTRACE)
 endif()
 
 if (${ENABLE_FPE})
+  message("Enabling FPE.")
   add_definitions(-DFPE)
 endif()
 

--- a/micro-apps/p3/perf_cmp.cpp
+++ b/micro-apps/p3/perf_cmp.cpp
@@ -67,7 +67,9 @@ int main (int argc, char** argv) {
     return -1;
   }
 
-  Real tol = util::TOL;
+  // When performance testing, we're using optimized flags, etc., so
+  // even in double precision we have to accept *some* diffs.
+  Real tol = util::is_single_precision<Real>::value ? 2e-5 : 1e-14;
   bool verbose = false;
   for (Int i = 1; i < argc-1; ++i) {
     if (util::eq(argv[i], "-v", "--verbose")) verbose = true;

--- a/micro-apps/p3/run_and_cmp.cpp
+++ b/micro-apps/p3/run_and_cmp.cpp
@@ -369,7 +369,8 @@ static Int run_and_cmp (const std::string& bfn, const Real& tol, bool verbose) {
           micro_sed_func_cpp(d_vanilla_cpp, vcpp_bridge);
           std::stringstream ss;
           ss << "Super-vanilla C++ step " << step;
-          Real fortran_tol = (tol < util::TOL) ? util::TOL : tol;
+          const Real sptol = 2e-5;
+          Real fortran_tol = (util::is_single_precision<Real>::value && tol < sptol) ? sptol : tol;
           nerr += compare(ss.str(), d_ref, d_vanilla_cpp, fortran_tol, verbose);
         }
 
@@ -377,7 +378,11 @@ static Int run_and_cmp (const std::string& bfn, const Real& tol, bool verbose) {
           micro_sed_func_cpp_kokkos(d_kokkos_cpp, kcpp_bridge, msvk);
           std::stringstream ss;
           ss << "Vanilla Kokkos C++ step " << step;
-          Real kokkos_tol = (tol < util::TOL) ? util::TOL : tol;
+          const Real sptol = 2e-5;
+          Real kokkos_tol = (util::is_single_precision<Real>::value && tol < sptol) ? sptol : tol;
+          // Sanity check.
+          micro_throw_if( ! util::is_single_precision<Real>::value && tol != 0,
+                          "We want BFB in double precision, at least in DEBUG builds.");
           nerr += compare(ss.str(), d_ref, d_kokkos_cpp, kokkos_tol, verbose);
         }
       }

--- a/micro-apps/p3/util.hpp
+++ b/micro-apps/p3/util.hpp
@@ -113,8 +113,6 @@ void set_min_max (const Integer& lim0, const Integer& lim1,
   max = util::max(lim0, lim1);
 }
 
-constexpr Real TOL = 2e-5; // a default tolerance high enough to handle round-off differences
-
 inline
 std::string active_avx_string () {
   std::string s;


### PR DESCRIPTION
We want clean ctests on all platforms. On some, with optimized
builds, that's impossible. If building DEBUG, disable
vectorization, and enable FPE.

Fix an issue in the regression tester. We require BFB in double
precision debug builds. The tol specification was erroneously
altered to allow non-BFB (with, in fact, a very loose tolerance)
in this special build. Insert a sanity check to protect this
requirement in the future. Remove the convenient TOL b/c we want
it to be inconvenient to request other than BFB.