### PR TITLE
Compiler workaround.

### DIFF
--- a/micro-apps/p3/initial_conditions.hpp
+++ b/micro-apps/p3/initial_conditions.hpp
@@ -34,7 +34,7 @@ template <typename Scalar>
 static void set_hydrostatic (const Int nk, Scalar* const dzq, Scalar* const pres) {
   const auto dp = (consts::pres_top - consts::pres_surface) / nk;
   const auto c1 = consts::R_d/consts::g, c2 = consts::R_d/consts::c_p;
-  Real z_prev = 0, z;
+  volatile Real z_prev = 0, z;
   for (Int k = 0; k < nk; ++k) {
     const auto p = consts::pres_surface + (k+1)*dp;
     pres[k] = p - 0.5*dp;


### PR DESCRIPTION
The perf drivers weren't running correctly in a build with Intel
17 on KNL, opt flags. Turns out it's b/c the ICs weren't filling
correctly b/c of an error in the dz arrays. This error was a
result of a compiler mistranslation. I used the usual technique
of letting the compiler know it overlooked a loop dependency:
adding volatile to the variable that causes the dependency.