### PR TITLE
Fix simd loop for Intel 18.

### DIFF
--- a/micro-apps/p3/scream_pack.hpp
+++ b/micro-apps/p3/scream_pack.hpp
@@ -21,7 +21,8 @@ struct Mask {
   KOKKOS_FORCEINLINE_FUNCTION explicit Mask () {}
 
   KOKKOS_FORCEINLINE_FUNCTION Mask (const bool& init) {
-    vector_simd for (int i = 0; i < n; ++i) d[i] = init;
+    //vector_simd // Intel 18 is having an issue with this loop.
+    for (int i = 0; i < n; ++i) d[i] = init;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION void set (const int& i, const bool& val) { d[i] = val; }


### PR DESCRIPTION
We noticed that ctest was failing on SKX with Intel 18. Cause was traced to one
loop. Comment out simd annotation for now. Intel 17 is OK on the code, so it's
likely eventually we can use it again.

I hosed our first data collection by not detecting this issue earlier. Go me!