### PR TITLE
Enable table test

### DIFF
--- a/micro-apps/p3/p3_unit_test.cpp
+++ b/micro-apps/p3/p3_unit_test.cpp
@@ -233,9 +233,9 @@ struct TestTable3 {
     check_growth("mu_r", slopes[1]/slopes[0]);
 
     // Study the lamr direction.
-    N = 1000;
+    N = 4000;
     for (Int refine = 0; refine < nslopes; ++refine) {
-      N *= 10;
+      N *= 2;
       const Scalar delta = 1.0/N;
 
       // Compute the slope magnitude at a specific (mu_r, lamr) in the lamr
@@ -477,12 +477,12 @@ int main (int argc, char** argv) {
   using Globals = p3::micro_sed::Globals<Real>;
   for (size_t i = 0; i < Globals::VN_TABLE.size(); ++i) {
     for (size_t j = 0; j < Globals::VN_TABLE[0].size(); ++j) {
-      Globals::VN_TABLE[i][j] = i + j;
-      Globals::VM_TABLE[i][j] = i * j;
+      Globals::VN_TABLE[i][j] = 1 + i + j;
+      Globals::VM_TABLE[i][j] = 1 + i * j;
     }
   }
   for (size_t i = 0; i < Globals::MU_R_TABLE.size(); ++i) {
-    Globals::MU_R_TABLE[i] = i;
+    Globals::MU_R_TABLE[i] = 1 + i;
   }
 
   int out = 0; // running error count
@@ -499,7 +499,7 @@ int main (int argc, char** argv) {
 #endif
     Kokkos::initialize(argc, argv); {
       // thread-insensitive tests
-      if (nt == upper) {
+      if (brief || nt == upper) {
         wrap_test("table3", UnitTest<>::TestTable3::run());
       }
 


### PR DESCRIPTION
WIP because this test is failing on GPU machines:

```
Table3 FAIL: Slopes in the lamr direction are 1946.51 and 2431.98, which grows by factor 1.24941. Near 1 is good; near 10 is bad.
```
