### PR TITLE
Refactor lin-interp work.

### DIFF
--- a/micro-apps/lin-interp/li_kokkos.hpp
+++ b/micro-apps/lin-interp/li_kokkos.hpp
@@ -46,97 +46,100 @@ struct LiKokkos
     m_minthresh(minthresh),
     m_init(false),
     m_policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, km2)),
-    m_indx_map("m_indx_map", km2)
+    m_indx_map("m_indx_map", ncol, km2)
 #ifndef NDEBUG
-    , m_indx_map_dbg("m_indx_map_dbg", km2)
+    , m_indx_map_dbg("m_indx_map_dbg", ncol, km2)
 #endif
   {}
 
   int km1_pack() const { return m_km1; }
   int km2_pack() const { return m_km2; }
 
-  void lin_interp(const view_2d<const Scalar>& x1, const view_2d<const Scalar>& x2, const view_2d<const Scalar>& y1,
-                  const view_2d<Scalar>& y2)
+  void setup(const view_2d<const Scalar>& x1, const view_2d<const Scalar>& x2)
   {
-    lin_interp_impl(*this, x1, x2, y1, y2);
-  }
-
-  // Linearly interpolate y(x1) onto coordinates x2
-  static void lin_interp_impl(
-    LiKokkos& lik,
-    const view_2d<const Scalar>& x1, const view_2d<const Scalar>& x2, const view_2d<const Scalar>& y1,
-    const view_2d<Scalar>& y2)
-  {
-    if (!lik.m_init) {
-      setup_nlogn(lik, util::subview(x1, 0), util::subview(x2, 0));
+    if (!m_init) {
+      setup_nlogn(*this, x1, x2);
 #ifndef NDEBUG
-      setup_n2(lik, util::subview(x1, 0), util::subview(x2, 0));
+      setup_n2(*this, x1, x2);
 #endif
     }
 
-    Kokkos::parallel_for("lin_interp", lik.m_policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, lik.m_km2), [&] (Int k2) {
-        micro_kassert(lik.m_indx_map(k2) == lik.m_indx_map_dbg(k2));
-        const int k1 = lik.m_indx_map(k2);
-        if (k1+1 == lik.m_km1) {
-          y2(i,k2) = y1(i,k1) + (y1(i,k1)-y1(i,k1-1))*(x2(i,k2)-x1(i,k1))/(x1(i,k1)-x1(i,k1-1));
-        }
-        else {
-          y2(i,k2) = y1(i,k1) + (y1(i,k1+1)-y1(i,k1))*(x2(i,k2)-x1(i,k1))/(x1(i,k1+1)-x1(i,k1));
-        }
+    m_init = true;
+  }
 
-        if (y2(i,k2) < lik.m_minthresh) {
-          y2(i,k2) = lik.m_minthresh;
-        }
+  KOKKOS_INLINE_FUNCTION
+  void lin_interp(const view_1d<const Scalar>& x1, const view_1d<const Scalar>& x2, const view_1d<const Scalar>& y1,
+                  const view_1d<Scalar>& y2, const MemberType& team) const
+  {
+    lin_interp_impl(*this, x1, x2, y1, y2, team);
+  }
 
-      });
+  // Linearly interpolate y(x1) onto coordinates x2
+  KOKKOS_INLINE_FUNCTION
+  static void lin_interp_impl(
+    const LiKokkos& lik,
+    const view_1d<const Scalar>& x1, const view_1d<const Scalar>& x2, const view_1d<const Scalar>& y1,
+    const view_1d<Scalar>& y2, const MemberType& team)
+  {
+    micro_kassert_msg(lik.m_init, "Not set up");
+
+    const int i = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, lik.m_km2), [&] (Int k2) {
+      micro_kassert(lik.m_indx_map(i, k2) == lik.m_indx_map_dbg(i, k2));
+      const int k1 = lik.m_indx_map(i, k2);
+      if (k1+1 == lik.m_km1) {
+        y2(k2) = y1(k1) + (y1(k1)-y1(k1-1))*(x2(k2)-x1(k1))/(x1(k1)-x1(k1-1));
+      }
+      else {
+        y2(k2) = y1(k1) + (y1(k1+1)-y1(k1))*(x2(k2)-x1(k1))/(x1(k1+1)-x1(k1));
+      }
+
+      if (y2(k2) < lik.m_minthresh) {
+        y2(k2) = lik.m_minthresh;
+      }
     });
   }
 
 #ifndef NDEBUG
-  static void setup_n2(LiKokkos& lik, const view_1d<const Scalar>& x1, const view_1d<const Scalar>& x2)
+  static void setup_n2(LiKokkos& lik, const view_2d<const Scalar>& x1, const view_2d<const Scalar>& x2)
   {
-    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(lik.m_km2, lik.m_km1-1));
-
-    Kokkos::parallel_for("setup_n2", policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int k2 = team.league_rank();
-      if( x2(k2) <= x1(0) ) { // x2[k2] comes before x1[0]
-        lik.m_indx_map_dbg(k2) = 0;
-      }
-      else if( x2(k2) >= x1(lik.m_km1-1) ) { // x2[k2] comes after x1[-1]
-        lik.m_indx_map_dbg(k2) = lik.m_km1-1;
-      }
-      else {
-        int k1_max = 0;
-        Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, lik.m_km1), [&] (int k1_arg, int& k1_max) {
-          const int k1 = k1_arg + 1;
-          if( (x2(k2)>=x1(k1-1)) && (x2(k2)<x1(k1)) ) { // check if x2[k2] lies within x1[k1-1] and x1[k1]
-            k1_max = k1-1;
+    Kokkos::parallel_for("setup_n2", lik.m_policy, KOKKOS_LAMBDA(const MemberType& team) {
+      const int i = team.league_rank();
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, lik.m_km2), [&] (Int k2) {
+        if( x2(i, k2) <= x1(i, 0) ) { // x2[k2] comes before x1[0]
+          lik.m_indx_map_dbg(i, k2) = 0;
+        }
+        else if( x2(i, k2) >= x1(i, lik.m_km1-1) ) { // x2[k2] comes after x1[-1]
+          lik.m_indx_map_dbg(i, k2) = lik.m_km1-1;
+        }
+        else {
+          for (int k1 = 1; k1 < lik.m_km1; ++k1) { // scan over x1
+            if( (x2(i, k2)>=x1(i, k1-1)) && (x2(i, k2)<x1(i, k1)) ) { // check if x2[k2] lies within x1[k1-1] and x1[k1]
+              lik.m_indx_map_dbg(i, k2) = k1-1;
+            }
           }
-        }, Kokkos::Max<int>(k1_max));
-        lik.m_indx_map_dbg(k2) = k1_max;
-      }
+        }
+      });
     });
   }
 #endif
 
-  static void setup_nlogn(LiKokkos& lik, const view_1d<const Scalar>& x1, const view_1d<const Scalar>& x2)
+  static void setup_nlogn(LiKokkos& lik, const view_2d<const Scalar>& x1, const view_2d<const Scalar>& x2)
   {
-    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(lik.m_km2, 1));
+    Kokkos::parallel_for("setup_nlogn", lik.m_policy, KOKKOS_LAMBDA(const MemberType& team) {
+      const int i = team.league_rank();
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, lik.m_km2), [&] (Int k2) {
+        const Scalar x1_indv = x2(i, k2);
+        auto begin = &x1(i, 0);
+        auto upper = begin + lik.m_km1;
 
-    Kokkos::parallel_for("setup_nlogn", policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int k2 = team.league_rank();
-      const Scalar x1_indv = x2(k2);
-      auto begin = &x1(0);
-      auto upper = begin + lik.m_km1;
-
-      auto ub = util::upper_bound(begin, upper, x1_indv);
-      int x1_idx = ub - begin;
-      if (x1_idx > 0) {
-        --x1_idx;
-      }
-      lik.m_indx_map(k2) = x1_idx;
+        auto ub = util::upper_bound(begin, upper, x1_indv);
+        int x1_idx = ub - begin;
+        if (x1_idx > 0) {
+          --x1_idx;
+        }
+        lik.m_indx_map(i, k2) = x1_idx;
+      });
     });
   }
 
@@ -146,9 +149,9 @@ struct LiKokkos
   Scalar m_minthresh;
   bool m_init;
   TeamPolicy m_policy;
-  view_1d<int> m_indx_map; // [x2-idx] -> x1-idx
+  view_2d<int> m_indx_map; // [x2-idx] -> x1-idx
 #ifndef NDEBUG
-  view_1d<int> m_indx_map_dbg; // [x2-idx] -> x1-idx
+  view_2d<int> m_indx_map_dbg; // [x2-idx] -> x1-idx
 #endif
 };
 

--- a/micro-apps/lin-interp/li_vanilla.hpp
+++ b/micro-apps/lin-interp/li_vanilla.hpp
@@ -11,42 +11,41 @@ struct LiVanilla
 {
   static constexpr const char* NAME = "vanilla";
 
-  LiVanilla(int ncol, int km1, int km2, Scalar minthresh) :
-    m_ncol(ncol),
+  LiVanilla(int /*ncol*/, int km1, int km2, Scalar minthresh) :
     m_km1(km1),
     m_km2(km2),
     m_minthresh(minthresh)
   {}
 
+  void setup(const vector_2d_t<Scalar>& /*x1*/, const vector_2d_t<Scalar>& /*x2*/)
+  {}
+
   // Linearly interpolate y(x1) onto coordinates x2
-  void lin_interp(const vector_2d_t<Scalar>& x1, const vector_2d_t<Scalar>& x2, const vector_2d_t<Scalar>& y1,
-                  vector_2d_t<Scalar>& y2) const
+  void lin_interp(const std::vector<Scalar>& x1, const std::vector<Scalar>& x2, const std::vector<Scalar>& y1,
+                  std::vector<Scalar>& y2, int /*i*/) const
   {
-    for (int i = 0; i < m_ncol; ++i) {
-      for (int k2 = 0; k2 < m_km2; ++k2) {
-        if( x2[i][k2] <= x1[i][0] ) {
-          y2[i][k2] = y1[i][0] + (y1[i][1]-y1[i][0])*(x2[i][k2]-x1[i][0])/(x1[i][1]-x1[i][0]);
-        }
-        else if( x2[i][k2] >= x1[i][m_km1-1] ) {
-          y2[i][k2] = y1[i][m_km1-1] + (y1[i][m_km1-1]-y1[i][m_km1-2])*(x2[i][k2]-x1[i][m_km1-1])/(x1[i][m_km1-1]-x1[i][m_km1-2]);
-        }
-        else {
-          for (int k1 = 1; k1 < m_km1; ++k1) {
-            if( (x2[i][k2]>=x1[i][k1-1]) && (x2[i][k2]<x1[i][k1]) ) {
-              y2[i][k2] = y1[i][k1-1] + (y1[i][k1]-y1[i][k1-1])*(x2[i][k2]-x1[i][k1-1])/(x1[i][k1]-x1[i][k1-1]);
-            }
+    for (int k2 = 0; k2 < m_km2; ++k2) {
+      if( x2[k2] <= x1[0] ) {
+        y2[k2] = y1[0] + (y1[1]-y1[0])*(x2[k2]-x1[0])/(x1[1]-x1[0]);
+      }
+      else if( x2[k2] >= x1[m_km1-1] ) {
+        y2[k2] = y1[m_km1-1] + (y1[m_km1-1]-y1[m_km1-2])*(x2[k2]-x1[m_km1-1])/(x1[m_km1-1]-x1[m_km1-2]);
+      }
+      else {
+        for (int k1 = 1; k1 < m_km1; ++k1) {
+          if( (x2[k2]>=x1[k1-1]) && (x2[k2]<x1[k1]) ) {
+            y2[k2] = y1[k1-1] + (y1[k1]-y1[k1-1])*(x2[k2]-x1[k1-1])/(x1[k1]-x1[k1-1]);
           }
         }
+      }
 
-        if (y2[i][k2] < m_minthresh) {
-          y2[i][k2] = m_minthresh;
-        }
+      if (y2[k2] < m_minthresh) {
+        y2[k2] = m_minthresh;
       }
     }
   }
 
  private:
-  int m_ncol;
   int m_km1;
   int m_km2;
   Scalar m_minthresh;

--- a/micro-apps/lin-interp/li_vect.hpp
+++ b/micro-apps/lin-interp/li_vect.hpp
@@ -56,118 +56,125 @@ struct LiVect
     m_minthresh(minthresh),
     m_init(false),
     m_policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(ncol, m_km2_pack)),
-    m_indx_map("m_indx_map", scream::pack::npack<IntPack>(km2))
+    m_indx_map("m_indx_map", ncol, scream::pack::npack<IntPack>(km2))
 #ifndef NDEBUG
-    , m_indx_map_dbg("m_indx_map_dbg", scream::pack::npack<IntPack>(km2))
+    , m_indx_map_dbg("m_indx_map_dbg", ncol, scream::pack::npack<IntPack>(km2))
 #endif
   {}
 
   int km1_pack() const { return m_km1_pack; }
   int km2_pack() const { return m_km2_pack; }
 
-  // Linearly interpolate y(x1) onto coordinates x2
-  void lin_interp(const view_2d<const Pack>& x1, const view_2d<const Pack>& x2, const view_2d<const Pack>& y1,
-                  const view_2d<Pack>& y2)
+  void setup(const view_2d<const Pack>& x1, const view_2d<const Pack>& x2)
   {
-    lin_interp_impl(*this, x1, x2, y1, y2);
-  }
-
-  static void lin_interp_impl(LiVect& liv,
-                              const view_2d<const Pack>& x1, const view_2d<const Pack>& x2, const view_2d<const Pack>& y1,
-                              const view_2d<Pack>& y2)
-  {
-    if (!liv.m_init) {
-      // assumes all cols have the same coords
-      setup_nlogn(liv, util::subview(x1, 0), util::subview(x2, 0));
+    if (!m_init) {
+      setup_nlogn(*this, x1, x2);
 #ifndef NDEBUG
-      setup_n2(liv, util::subview(x1, 0), util::subview(x2, 0));
+      setup_n2(*this, x1, x2);
 #endif
     }
 
-    Kokkos::parallel_for("lin_interp", liv.m_policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int i = team.league_rank();
-      auto x1s = scalarize(util::subview(x1, i));
-      auto x2s = util::subview(x2, i);
-      auto y1s = scalarize(util::subview(y1, i));
-      auto y2s = util::subview(y2, i);
+    m_init = true;
+  }
 
-      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, liv.m_km2_pack), [&] (Int k2) {
-        const auto indx_pk = liv.m_indx_map(k2);
-        micro_kassert((indx_pk == liv.m_indx_map_dbg(k2)).all());
-        const auto end_mask = indx_pk == liv.m_km1 - 1;
-        const auto not_end = !end_mask;
-        if (end_mask.any()) {
-          scream_masked_loop(end_mask, s) {
-            int k1 = indx_pk[s];
-            y2s(k2)[s] = y1s(k1) + (y1s(k1)-y1s(k1-1))*(x2s(k2)[s]-x1s(k1))/(x1s(k1)-x1s(k1-1));
-          }
-          scream_masked_loop(not_end, s) {
-            int k1 = indx_pk[s];
-            y2s(k2)[s] = y1s(k1) + (y1s(k1+1)-y1s(k1))*(x2s(k2)[s]-x1s(k1))/(x1s(k1+1)-x1s(k1));
-          }
-        }
-        else {
-          for (int s = 0; s < indx_pk.n; ++s) {
-            int k1 = indx_pk[s];
-            y2s(k2)[s] = y1s(k1) + (y1s(k1+1)-y1s(k1))*(x2s(k2)[s]-x1s(k1))/(x1s(k1+1)-x1s(k1));
-          }
-        }
+  // Linearly interpolate y(x1) onto coordinates x2
+  KOKKOS_INLINE_FUNCTION
+  void lin_interp(const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
+                  const view_1d<Pack>& y2, const MemberType& team) const
+  {
+    lin_interp_impl(*this, x1, x2, y1, y2, team);
+  }
 
-        y2s(k2).set(y2s(k2) < liv.m_minthresh, liv.m_minthresh);
-      });
+  KOKKOS_INLINE_FUNCTION
+  static void lin_interp_impl(const LiVect& liv,
+                              const view_1d<const Pack>& x1, const view_1d<const Pack>& x2, const view_1d<const Pack>& y1,
+                              const view_1d<Pack>& y2, const MemberType& team)
+  {
+    micro_kassert_msg(liv.m_init, "Not set up");
+
+    auto x1s = scalarize(x1);
+    auto y1s = scalarize(y1);
+
+    const int i = team.league_rank();
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, liv.m_km2_pack), [&] (Int k2) {
+      const auto indx_pk = liv.m_indx_map(i, k2);
+      micro_kassert((indx_pk == liv.m_indx_map_dbg(i, k2)).all());
+      const auto end_mask = indx_pk == liv.m_km1 - 1;
+      const auto not_end = !end_mask;
+      if (end_mask.any()) {
+        scream_masked_loop(end_mask, s) {
+          int k1 = indx_pk[s];
+          y2(k2)[s] = y1s(k1) + (y1s(k1)-y1s(k1-1))*(x2(k2)[s]-x1s(k1))/(x1s(k1)-x1s(k1-1));
+        }
+        scream_masked_loop(not_end, s) {
+          int k1 = indx_pk[s];
+          y2(k2)[s] = y1s(k1) + (y1s(k1+1)-y1s(k1))*(x2(k2)[s]-x1s(k1))/(x1s(k1+1)-x1s(k1));
+        }
+      }
+      else {
+        for (int s = 0; s < indx_pk.n; ++s) {
+          int k1 = indx_pk[s];
+          y2(k2)[s] = y1s(k1) + (y1s(k1+1)-y1s(k1))*(x2(k2)[s]-x1s(k1))/(x1s(k1+1)-x1s(k1));
+        }
+      }
+
+      y2(k2).set(y2(k2) < liv.m_minthresh, liv.m_minthresh);
     });
   }
 
 #ifndef NDEBUG
-  static void setup_n2(LiVect& liv, const view_1d<const Pack>& x1, const view_1d<const Pack>& x2)
+  static void setup_n2(LiVect& liv, const view_2d<const Pack>& x1, const view_2d<const Pack>& x2)
   {
-    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(liv.m_km2, liv.m_km1-1));
+    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(liv.m_ncol, liv.m_km2));
 
     auto x1s = scalarize(x1);
     auto x2s = scalarize(x2);
     auto idxs = scalarize(liv.m_indx_map_dbg);
 
     Kokkos::parallel_for("setup_n2", policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int k2 = team.league_rank();
-      if( x2s(k2) <= x1s(0) ) { // x2[k2] comes before x1[0]
-        idxs(k2) = 0;
-      }
-      else if( x2s(k2) >= x1s(liv.m_km1-1) ) { // x2[k2] comes after x1[-1]
-        idxs(k2) = liv.m_km1-1;
-      }
-      else {
-        int k1_max = 0;
-        Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, liv.m_km1), [&] (int k1_arg, int& k1_max) {
-          const int k1 = k1_arg + 1;
-          if( (x2s(k2)>=x1s(k1-1)) && (x2s(k2)<x1s(k1)) ) { // check if x2[k2] lies within x1[k1-1] and x1[k1]
-            k1_max = k1-1;
+      const int i = team.league_rank();
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, liv.m_km2), [&] (Int k2) {
+
+        if( x2s(i, k2) <= x1s(i, 0) ) { // x2[k2] comes before x1[0]
+          idxs(i, k2) = 0;
+        }
+        else if( x2s(i, k2) >= x1s(i, liv.m_km1-1) ) { // x2[k2] comes after x1[-1]
+          idxs(i, k2) = liv.m_km1-1;
+        }
+        else {
+          for (int k1 = 1; k1 < liv.m_km1; ++k1) { // scan over x1
+            if( (x2s(i, k2)>=x1s(i, k1-1)) && (x2s(i, k2)<x1s(i, k1)) ) { // check if x2[k2] lies within x1[k1-1] and x1[k1]
+              idxs(i, k2) = k1-1;
+            }
           }
-        }, Kokkos::Max<int>(k1_max));
-        idxs(k2) = k1_max;
-      }
+        }
+      });
     });
   }
 #endif
 
-  static void setup_nlogn(LiVect& liv, const view_1d<const Pack>& x1, const view_1d<const Pack>& x2)
+  static void setup_nlogn(LiVect& liv, const view_2d<const Pack>& x1, const view_2d<const Pack>& x2)
   {
-    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(liv.m_km2, 1));
+    TeamPolicy policy(util::ExeSpaceUtils<ExeSpace>::get_default_team_policy(liv.m_ncol, liv.m_km2));
     auto x1s = scalarize(x1);
     auto x2s = scalarize(x2);
     auto idxs = scalarize(liv.m_indx_map);
 
     Kokkos::parallel_for("setup_nlogn", policy, KOKKOS_LAMBDA(const MemberType& team) {
-      const int k2 = team.league_rank();
-      const Scalar x1_indv = x2s(k2);
-      auto begin = &x1s(0);
-      auto upper = begin + liv.m_km1;
+      const int i = team.league_rank();
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team, liv.m_km2), [&] (Int k2) {
 
-      auto ub = util::upper_bound(begin, upper, x1_indv);
-      int x1_idx = ub - begin;
-      if (x1_idx > 0) {
-        --x1_idx;
-      }
-      idxs(k2) = x1_idx;
+        const Scalar x1_indv = x2s(i, k2);
+        auto begin = &x1s(i, 0);
+        auto upper = begin + liv.m_km1;
+
+        auto ub = util::upper_bound(begin, upper, x1_indv);
+        int x1_idx = ub - begin;
+        if (x1_idx > 0) {
+          --x1_idx;
+        }
+        idxs(i, k2) = x1_idx;
+      });
     });
   }
 
@@ -179,9 +186,9 @@ struct LiVect
   Scalar m_minthresh;
   bool m_init;
   TeamPolicy m_policy;
-  view_1d<IntPack> m_indx_map; // [x2-idx] -> x1-idx
+  view_2d<IntPack> m_indx_map; // [x2-idx] -> x1-idx
 #ifndef NDEBUG
-  view_1d<IntPack> m_indx_map_dbg; // [x2-idx] -> x1-idx
+  view_2d<IntPack> m_indx_map_dbg; // [x2-idx] -> x1-idx
 #endif
 };
 

--- a/micro-apps/share/scream_pack.hpp
+++ b/micro-apps/share/scream_pack.hpp
@@ -428,6 +428,13 @@ scalarize (const Kokkos::View<Pack<T, pack_size>**, Parms...>& vp) {
 }
 
 template <typename T, typename ...Parms, int pack_size> KOKKOS_FORCEINLINE_FUNCTION
+Unmanaged<Kokkos::View<const T**, Parms...> >
+scalarize (const Kokkos::View<const Pack<T, pack_size>**, Parms...>& vp) {
+  return Unmanaged<Kokkos::View<const T**, Parms...> >(
+    reinterpret_cast<const T*>(vp.data()), vp.extent_int(0), pack_size * vp.extent_int(1));
+}
+
+template <typename T, typename ...Parms, int pack_size> KOKKOS_FORCEINLINE_FUNCTION
 Unmanaged<Kokkos::View<T*, Parms...> >
 scalarize (const Kokkos::View<Pack<T, pack_size>*, Parms...>& vp) {
   return Unmanaged<Kokkos::View<T*, Parms...> >(


### PR DESCRIPTION
Do not assume consistent coords across all columns.

Lin-interp call must be done within kokkos pfor around cols.