### PR TITLE
Improve vectorization of li

### DIFF
--- a/micro-apps/lin-interp/li_vect.hpp
+++ b/micro-apps/lin-interp/li_vect.hpp
@@ -102,8 +102,8 @@ struct LiVect
       }
 #endif
       const auto end_mask = indx_pk == liv.m_km1 - 1;
-      const auto not_end = !end_mask;
       if (end_mask.any()) {
+        const auto not_end = !end_mask;
         scream_masked_loop(end_mask, s) {
           int k1 = indx_pk[s];
           y2(k2)[s] = y1s(k1) + (y1s(k1)-y1s(k1-1))*(x2(k2)[s]-x1s(k1))/(x1s(k1)-x1s(k1-1));
@@ -115,9 +115,9 @@ struct LiVect
       }
       else {
         Pack x1p, x1p1, y1p, y1p1;
-        index_and_shift(x1s, indx_pk, 1, x1p, x1p1);
-        index_and_shift(y1s, indx_pk, 1, y1p, y1p1);
-        const auto x2p = x2(k2);
+        scream::pack::index_and_shift<1>(x1s, indx_pk, x1p, x1p1);
+        scream::pack::index_and_shift<1>(y1s, indx_pk, y1p, y1p1);
+        const auto& x2p = x2(k2);
 
         y2(k2) = y1p + (y1p1-y1p)*(x2p-x1p)/(x1p1-x1p);
       }

--- a/micro-apps/share/scream_pack.hpp
+++ b/micro-apps/share/scream_pack.hpp
@@ -388,13 +388,14 @@ index (const Array1& a, const IdxPack& i0,
   return p;
 }
 
-template<typename Array1, typename IdxPack> KOKKOS_INLINE_FUNCTION
+template<int Shift, typename Array1, typename IdxPack> KOKKOS_INLINE_FUNCTION
 void
-index_and_shift (const Array1& a, const IdxPack& i0, const int shift, Pack<typename Array1::non_const_value_type, IdxPack::n>& index, Pack<typename Array1::non_const_value_type, IdxPack::n>& index_shift,
+index_and_shift (const Array1& a, const IdxPack& i0, Pack<typename Array1::non_const_value_type, IdxPack::n>& index, Pack<typename Array1::non_const_value_type, IdxPack::n>& index_shift,
        typename std::enable_if<Array1::Rank == 1>::type* = nullptr) {
   vector_simd for (int i = 0; i < IdxPack::n; ++i) {
-    index[i]       = a(i0[i]);
-    index_shift[i] = a(i0[i] + shift);
+    const auto i0i = i0[i];
+    index[i]       = a(i0i);
+    index_shift[i] = a(i0i + Shift);
   }
 }
 


### PR DESCRIPTION
@ambrad , just putting this up so we can discuss. I was a bit tripped up by the

```
y1s(k1+1)
```

... term in the original code. This appears to me to force us to make an additional index-lookup pack:

```
const auto y1p1 = index(y1s, indx_pk+1);
```

Which adds considerable overhead.

Am I not seeing a better approach here?

Preliminary results show a pretty good speedup on bowman but a slowdown on blake.