### PR TITLE
Add folder containing yaml templates that MUST be kept working at all times

### DIFF
--- a/v1_output/README.md
+++ b/v1_output/README.md
@@ -1,0 +1,11 @@
+This folder contains examples of output files that match a "typical" EAMxx run.
+
+As the E3SM repo is updated, the syntax for output yaml files *may* change. However,
+the templates in the 'master' folder are *guaranteed* to always run with the current master version.
+
+If for some reason you find that one of those yaml files does NOT work, please, contact
+one of the following people:
+
+- Luca Bertagna, lbertag@sandia.gov
+- Naser Mahfouz, naser.mahfouz@pnnl.gov
+- Aaron Donahue, donahue5@llnl.gov

--- a/v1_output/master/CHANGELOG.txt
+++ b/v1_output/master/CHANGELOG.txt
@@ -1,0 +1,1 @@
+* Jul 3, 2025: change "Key Name" to "key_name" in yaml files, following recent E3SM change

--- a/v1_output/master/scream_output.decadal.15minINST_ARM.yaml
+++ b/v1_output/master/scream_output.decadal.15minINST_ARM.yaml
@@ -1,0 +1,35 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.15minINST_ARM
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 96  # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_DecadalSites_c20240130.nc
+fields:
+  physics_pg2:
+    field_names:
+    # 2D
+    - SW_flux_dn_at_model_bot
+    - SW_flux_up_at_model_bot
+    - LW_flux_dn_at_model_bot
+    - LW_flux_up_at_model_bot
+    - SW_flux_up_at_model_top
+    - LW_flux_up_at_model_top
+    - SW_flux_dn_at_model_top
+    - surf_sens_flux
+    - surf_evap
+    - ps
+    - precip_liq_surf_mass_flux
+    - precip_ice_surf_mass_flux
+    - T_2m
+    - qv_2m
+    - VapWaterPath
+    - LiqWaterPath
+    - IceWaterPath
+    - RainWaterPath
+    - wind_speed_10m
+output_control:
+  frequency: 15
+  frequency_units: nmins
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.1dailyAVG_ne1024pg2.yaml
+++ b/v1_output/master/scream_output.decadal.1dailyAVG_ne1024pg2.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.1dailyAVG_ne1024pg2
+iotype: pnetcdf
+averaging_type: Average
+max_snapshots_per_file: 1
+fields:
+  physics_pg2:
+    field_names:
+    - snow_depth_land
+output_control:
+  frequency: 1
+  frequency_units: ndays
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.1dailyMAX_ne1024pg2.yaml
+++ b/v1_output/master/scream_output.decadal.1dailyMAX_ne1024pg2.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.1dailyMAX_ne1024pg2
+iotype: pnetcdf
+averaging_type: Max
+max_snapshots_per_file: 1
+fields:
+  physics_pg2:
+    field_names:
+    - T_2m
+    - precip_total_surf_mass_flux
+output_control:
+  frequency: 1
+  frequency_units: ndays
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.1dailyMIN_ne1024pg2.yaml
+++ b/v1_output/master/scream_output.decadal.1dailyMIN_ne1024pg2.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.1dailyMIN_ne1024pg2
+iotype: pnetcdf
+averaging_type: Min
+max_snapshots_per_file: 1
+fields:
+  physics_pg2:
+    field_names:
+    - T_2m
+output_control:
+  frequency: 1
+  frequency_units: ndays
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.1hourlyINST_ARM.yaml
+++ b/v1_output/master/scream_output.decadal.1hourlyINST_ARM.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.1hourlyINST_ARM
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 24  # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_DecadalSites_c20240130.nc
+fields:
+  physics_pg2:
+    field_names:
+    # 3D
+    - T_mid
+    - RelativeHumidity
+    - qc
+    - qi
+    - qr
+    - qm
+    - ps
+    - cldfrac_tot_for_analysis
+    - cldfrac_liq
+    - cldfrac_ice_for_analysis
+    - omega
+    - tke
+    - eff_radius_qc
+    - eff_radius_qi
+    - nc
+    - ni
+    - nr
+    - bm
+    - p_mid
+    - z_mid
+    - U
+    - V
+    - landfrac
+output_control:
+  frequency: 1
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.1hourlyINST_ne1024pg2.yaml
+++ b/v1_output/master/scream_output.decadal.1hourlyINST_ne1024pg2.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.1hourlyINST_ne1024pg2
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 24
+fields:
+  physics_pg2:
+    field_names:
+    # For cloud morphology
+    - SW_flux_up_at_model_top
+    - LW_flux_up_at_model_top
+    - precip_total_surf_mass_flux
+output_control:
+  frequency: 1
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.3hourlyAVG_ne30pg2.yaml
+++ b/v1_output/master/scream_output.decadal.3hourlyAVG_ne30pg2.yaml
@@ -1,0 +1,68 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.3hourlyAVG_ne30pg2
+iotype: pnetcdf
+averaging_type: Average
+max_snapshots_per_file: 8 # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_ne30pg2_mono.20230901.nc
+fields:
+  physics_pg2:
+    field_names:
+    # 3D fields
+    - T_mid
+    - qv
+    - qc
+    - qr
+    - qi
+    - cldfrac_tot
+    - cldfrac_liq
+    - omega
+    - U
+    - V
+    - pseudo_density
+    - z_mid
+    # Surface
+    - surf_sens_flux
+    - surf_evap
+    - surface_upward_latent_heat_flux
+    - ps
+    - precip_liq_surf_mass_flux
+    - precip_ice_surf_mass_flux
+    - surf_mom_flux
+    - surf_radiative_T
+    - T_2m
+    - sfc_flux_dir_nir
+    - sfc_flux_dir_vis
+    - sfc_flux_dif_nir
+    - sfc_flux_dif_vis
+    - sfc_flux_sw_net
+    - sfc_flux_lw_dn
+    # Lowest Level
+    - U_at_model_bot
+    - V_at_model_bot
+    - T_mid_at_model_bot
+    - qv_at_model_bot
+    - qc_at_model_bot
+    - qi_at_model_bot
+    - qr_at_model_bot
+    - qm_at_model_bot
+    - bm_at_model_bot
+    - SW_flux_up_at_model_top
+    - SW_flux_dn_at_model_top
+    - LW_flux_up_at_model_top
+    - SW_clrsky_flux_up_at_model_top
+    - LW_clrsky_flux_up_at_model_top
+    - SW_flux_dn_at_model_bot
+    - SW_clrsky_flux_dn_at_model_bot
+    - SW_flux_up_at_model_bot
+    - SW_clrsky_flux_up_at_model_bot
+    - LW_flux_dn_at_model_bot
+    - LW_clrsky_flux_dn_at_model_bot
+    - LW_flux_up_at_model_bot
+    - LongwaveCloudForcing
+    - ShortwaveCloudForcing
+output_control:
+  frequency: 3
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.3hourlyINST_ne30pg2.yaml
+++ b/v1_output/master/scream_output.decadal.3hourlyINST_ne30pg2.yaml
@@ -1,0 +1,69 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.3hourlyINST_ne30pg2
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 8  # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_ne30pg2_mono.20230901.nc
+fields:
+  physics_pg2:
+    field_names:
+    # 2D vars for storm analysis
+    - SeaLevelPressure
+    - U_at_model_bot
+    - V_at_model_bot
+    - wind_speed_10m
+    - U_at_925hPa
+    - V_at_925hPa
+    - U_at_850hPa
+    - V_at_850hPa
+    - U_at_700hPa
+    - V_at_700hPa
+    - U_at_500hPa
+    - V_at_500hPa
+    - U_at_300hPa
+    - V_at_300hPa
+    - ZonalVapFlux
+    - MeridionalVapFlux
+    - T_2m
+    - qv_2m
+    - T_mid_at_925hPa
+    - T_mid_at_850hPa
+    - T_mid_at_700hPa
+    - T_mid_at_500hPa
+    - T_mid_at_300hPa
+    - RelativeHumidity_at_925hPa
+    - RelativeHumidity_at_850hPa
+    - RelativeHumidity_at_700hPa
+    - RelativeHumidity_at_500hPa
+    - RelativeHumidity_at_300hPa
+    - z_mid_at_925hPa
+    - z_mid_at_850hPa
+    - z_mid_at_700hPa
+    - z_mid_at_500hPa
+    - z_mid_at_300hPa
+    # 2D vars For ACI diagnostics
+    - SW_clrsky_flux_up_at_model_top
+    - SW_flux_up_at_model_top
+    - SW_flux_dn_at_model_top
+    - LiqWaterPath
+    - precip_liq_surf_mass_flux
+    - precip_ice_surf_mass_flux
+    - IceWaterPath
+    - cldfrac_tot_for_analysis
+    - cldfrac_liq
+    - omega_at_500hPa
+    - omega_at_700hPa
+    - omega_at_850hPa
+    - PotentialTemperature_at_700hPa
+    - PotentialTemperature_at_1000hPa
+    # 3D vars for nudging
+    - U
+    - V
+    # Surface pressure needed to calculate pressure levels
+    - ps
+output_control:
+  frequency: 3
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.6hourlyAVG_ne30pg2.yaml
+++ b/v1_output/master/scream_output.decadal.6hourlyAVG_ne30pg2.yaml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.6hourlyAVG_ne30pg2
+iotype: pnetcdf
+averaging_type: Average
+max_snapshots_per_file: 4  # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_ne30pg2_mono.20230901.nc 
+fields:
+  physics_pg2:
+    field_names:
+    # Full 3D Profile
+    - p3_T_mid_tend
+    - shoc_T_mid_tend
+    - rrtmgp_T_mid_tend
+    - homme_T_mid_tend
+    - p3_qv_tend
+    - shoc_qv_tend
+    - homme_qv_tend
+    - SW_flux_dn
+    - SW_flux_up
+    - LW_flux_dn
+    - LW_flux_up
+    # Surface
+    - surf_sens_flux
+    - surf_evap
+    - surface_upward_latent_heat_flux
+    - ps
+    - precip_liq_surf_mass_flux
+    - precip_ice_surf_mass_flux
+    - surf_mom_flux
+    - surf_radiative_T
+    - T_2m
+    # Lowest Level
+    - U_at_model_bot
+    - V_at_model_bot
+    - SW_flux_dn_at_model_bot
+    - SW_flux_up_at_model_bot
+    - LW_flux_dn_at_model_bot
+    - LW_flux_up_at_model_bot
+    - SW_flux_up_at_model_top
+    - SW_flux_dn_at_model_top
+    - LW_flux_up_at_model_top
+output_control:
+  frequency: 6
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.6hourlyINST_ne1024pg2.yaml
+++ b/v1_output/master/scream_output.decadal.6hourlyINST_ne1024pg2.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.6hourlyINST_ne1024pg2
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 4  # one file per day
+fields:
+  physics_pg2:
+    field_names:
+    # For storm analysis
+    - SeaLevelPressure
+    - wind_speed_10m
+    - z_mid_at_500hPa
+    - z_mid_at_200hPa
+    # For wind turbine study
+    - wind_speed_at_100m_above_surface
+    # For atmospheric rivers
+    - ZonalVapFlux
+    - MeridionalVapFlux
+    # Others
+    - omega_at_500hPa
+    - omega_at_850hPa
+output_control:
+  frequency: 6
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.6hourlyINST_ne30pg2.yaml
+++ b/v1_output/master/scream_output.decadal.6hourlyINST_ne30pg2.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+filename_prefix: output.scream.decadal.6hourlyINST_ne30pg2
+iotype: pnetcdf
+averaging_type: Instant
+max_snapshots_per_file: 4  # one file per day
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_ne30pg2_mono.20230901.nc
+fields:
+  physics_pg2:
+    field_names:
+    # 3D fields on model levels
+    - T_mid
+    - qv
+    - RelativeHumidity
+    - U
+    - V
+    - omega
+    - qc
+    - nc
+    - qr
+    - qi
+    - tke
+    - o3_volume_mix_ratio
+    # 2D fields
+    - VapWaterPath
+    - LiqWaterPath
+    - IceWaterPath
+    - surf_radiative_T
+    - ps
+    - qv_2m
+    - T_2m
+    - ocnfrac
+    - landfrac
+output_control:
+  frequency: 6
+  frequency_units: nhours
+restart:
+  force_new_file: true

--- a/v1_output/master/scream_output.decadal.monthlyAVG_ne30pg2.yaml
+++ b/v1_output/master/scream_output.decadal.monthlyAVG_ne30pg2.yaml
@@ -1,0 +1,95 @@
+%YAML 1.1
+---
+flush_frequency: 1
+filename_prefix: output.scream.decadal.monthlyAVG_ne30pg2
+iotype: pnetcdf
+averaging_type: Average
+max_snapshots_per_file: 1
+horiz_remap_file: ${DIN_LOC_ROOT}/atm/scream/maps/map_ne1024pg2_to_ne30pg2_mono.20230901.nc 
+fields:
+  physics_pg2:
+    field_names:
+    # 3D fields
+    - T_mid
+    - qv
+    - RelativeHumidity
+    - qc
+    - qi
+    - qr
+    - qm
+    - nc
+    - ni
+    - nr
+    - cldfrac_tot_for_analysis
+    - cldfrac_ice_for_analysis
+    - cldfrac_liq
+    - omega
+    - U
+    - V
+    - z_mid
+    - p_mid
+    - tke
+    # 2D fields
+    - SW_flux_up_at_model_top
+    - SW_flux_dn_at_model_top
+    - LW_flux_up_at_model_top
+    - SW_clrsky_flux_up_at_model_top
+    - SW_clrsky_flux_dn_at_model_top
+    - LW_clrsky_flux_up_at_model_top
+    - SW_flux_up_at_model_bot
+    - SW_flux_dn_at_model_bot
+    - LW_flux_up_at_model_bot
+    - LW_flux_dn_at_model_bot
+    - SW_clrsky_flux_up_at_model_bot
+    - SW_clrsky_flux_dn_at_model_bot
+    - LW_clrsky_flux_dn_at_model_bot
+    - ShortwaveCloudForcing
+    - LongwaveCloudForcing
+    - ps
+    - SeaLevelPressure
+    - T_2m
+    - qv_2m
+    - surf_radiative_T
+    - VapWaterPath
+    - IceWaterPath
+    - LiqWaterPath
+    - RainWaterPath
+    - ZonalVapFlux
+    - MeridionalVapFlux
+    - surf_evap
+    - surf_sens_flux
+    - surface_upward_latent_heat_flux
+    - precip_liq_surf_mass_flux
+    - precip_ice_surf_mass_flux
+    - landfrac
+    - ocnfrac
+    - PotentialTemperature_at_700hPa
+    - PotentialTemperature_at_850hPa
+    - PotentialTemperature_at_1000hPa
+    - PotentialTemperature_at_2m_above_surface
+    - omega_at_500hPa
+    - omega_at_700hPa
+    - omega_at_850hPa
+    - RelativeHumidity_at_700hPa
+    - RelativeHumidity_at_1000hPa
+    - RelativeHumidity_at_2m_above_surface
+    - wind_speed_10m
+    - z_mid_at_700hPa
+    - z_mid_at_1000hPa
+    - T_mid_at_850hPa
+    - T_mid_at_700hPa
+    # For SST advection
+    - U_at_10m_above_surface
+    - V_at_10m_above_surface
+    # COSP
+    - isccp_ctptau
+    - modis_ctptau
+    - misr_cthtau
+    - cosp_sunlit
+    - isccp_cldtot
+
+output_control:
+  frequency: 1
+  frequency_units: nmonths
+restart:
+  force_new_file: true


### PR DESCRIPTION
As E3SM is updated, we MUST ensure these yaml do work.

For now, I copied the content of the decadal folder.

NOTE: other folders should NOT be updated as master changes, as they should reflect the version of the code that they were used with. That is, if someone wants to re-run decadal simulations, they should simply checkout the decadal branch in E3SM, and use the yaml files in the decadal subfolders. OTOH, the `master` folder should contain yaml files that are kept working with the current master version. That is, at any given moment, one should be able to checkout the current E3SM master version and use the yaml files in the `master` folder without any problem (at least, without any problem related to IO..).

---

I am now testing that these do indeed work with current master...